### PR TITLE
Add SwiftUI authentication view

### DIFF
--- a/AppState.swift
+++ b/AppState.swift
@@ -1,0 +1,5 @@
+import Combine
+
+class AppState: ObservableObject {
+    @Published var isAuthenticated: Bool = false
+}

--- a/AurafyApp.swift
+++ b/AurafyApp.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import FirebaseCore
+
+@main
+struct AurafyApp: App {
+    @StateObject private var appState = AppState()
+
+    init() {
+        FirebaseApp.configure()
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            if appState.isAuthenticated {
+                ContentView()
+                    .environmentObject(appState)
+            } else {
+                AuthView()
+                    .environmentObject(appState)
+            }
+        }
+    }
+}

--- a/AuthView.swift
+++ b/AuthView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+import FirebaseAuth
+
+struct AuthView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var email: String = ""
+    @State private var password: String = ""
+    @State private var isLoginMode: Bool = true
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                Picker(selection: $isLoginMode, label: Text("Mode")) {
+                    Text("Login").tag(true)
+                    Text("Signup").tag(false)
+                }
+                .pickerStyle(SegmentedPickerStyle())
+                .padding(.horizontal)
+
+                TextField("Email", text: $email)
+                    .keyboardType(.emailAddress)
+                    .autocapitalization(.none)
+                    .padding()
+                    .background(Color(.secondarySystemBackground))
+                    .cornerRadius(8)
+                    .padding(.horizontal)
+
+                SecureField("Password", text: $password)
+                    .padding()
+                    .background(Color(.secondarySystemBackground))
+                    .cornerRadius(8)
+                    .padding(.horizontal)
+
+                if let error = errorMessage {
+                    Text(error)
+                        .foregroundColor(.red)
+                        .padding(.horizontal)
+                }
+
+                Button(action: submit) {
+                    Text(isLoginMode ? "Login" : "Signup")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                        .padding(.horizontal)
+                }
+                Spacer()
+            }
+            .navigationTitle(isLoginMode ? "Login" : "Signup")
+        }
+    }
+
+    private func submit() {
+        errorMessage = nil
+        if isLoginMode {
+            login()
+        } else {
+            signup()
+        }
+    }
+
+    private func login() {
+        Auth.auth().signIn(withEmail: email, password: password) { result, error in
+            if let error = error {
+                self.errorMessage = error.localizedDescription
+            } else {
+                self.appState.isAuthenticated = true
+            }
+        }
+    }
+
+    private func signup() {
+        Auth.auth().createUser(withEmail: email, password: password) { result, error in
+            if let error = error {
+                self.errorMessage = error.localizedDescription
+            } else {
+                self.appState.isAuthenticated = true
+            }
+        }
+    }
+}
+
+struct AuthView_Previews: PreviewProvider {
+    static var previews: some View {
+        AuthView().environmentObject(AppState())
+    }
+}

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Welcome!")
+            .font(.largeTitle)
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}


### PR DESCRIPTION
## Summary
- implement `AppState` environment object for authentication state
- add SwiftUI `AuthView` for login/signup using Firebase
- create `ContentView` to show after successful auth
- wire views together in `AurafyApp`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861ff7ab90c83228f07be811ee10fae